### PR TITLE
Fix #3 by adding a newline to every injected content

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function nodeInjectmd (opts) {
     function parse (line) {
       if (startTag.test(line.trim())) {
         tagMode = true
-        const res = line + EOL + String(inBuf) + EOL
+        const res = line + EOL + String(inBuf) + EOL + EOL
         return res
       } else if (endTag.test(line.trim())) {
         tagMode = false

--- a/test/fixtures/expected-regex.md
+++ b/test/fixtures/expected-regex.md
@@ -1,5 +1,6 @@
 <!-- START main-header -->
 # best header ever
+
 <!-- END main-header -->
 
 ## another section

--- a/test/fixtures/expected.md
+++ b/test/fixtures/expected.md
@@ -1,5 +1,6 @@
 <!--START main-header-->
 # best header ever
+
 <!--END main-header-->
 
 ## another section


### PR DESCRIPTION
@TabDigital/ping-api should fix the annoying bug where

``` bash
cat README.md | markdown-toc - | inject-md -t toc
```

would generate

```
- last table of contents item -->
```

So you had to force a newline with

``` bash
cat README.md | markdown-toc - | awk 1 | inject-md -t toc
```

Can anyone think of a case where adding the extra newline before `-->` will cause an issue?
